### PR TITLE
Fix undefined variable console.log

### DIFF
--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -275,9 +275,8 @@ function preloadAndOpenSchedule() {
     .catch(() => openSchedulePopup({}));
 }
 
-console.log("🧪 openSchedulePopup received:", existing);
-
 function openSchedulePopup(existing = {}) {
+  console.log("🧪 openSchedulePopup received:", existing);
   const popup = document.createElement('div');
   popup.style.position = 'fixed';
   popup.style.top = '10%';


### PR DESCRIPTION
## Summary
- move diagnostic logging inside `openSchedulePopup`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68406362ceb88326a142bab0245da321