### PR TITLE
Fix admin login redirect endpoint

### DIFF
--- a/src/routes/report.py
+++ b/src/routes/report.py
@@ -22,7 +22,7 @@ THRESHOLDS = config.get("report_time_thresholds", {"over_5": 300, "over_10": 600
 @report_bp.route('/admin_report')
 def admin_report():
     if not session.get('logged_in'):
-        return redirect(url_for('auth.admin_login'))
+        return redirect(url_for('auth.login'))
 
     report_data = []
 
@@ -57,7 +57,7 @@ def admin_report():
 @report_bp.route('/admin_report_csv')
 def admin_report_csv():
     if not session.get('logged_in'):
-        return redirect(url_for('auth.admin_login'))
+        return redirect(url_for('auth.login'))
 
     output = StringIO()
     writer = csv.writer(output)
@@ -87,7 +87,7 @@ def admin_report_csv():
 @report_bp.route('/admin_pass_history')
 def admin_pass_history():
     if not session.get('logged_in'):
-        return redirect(url_for('auth.admin_login'))
+        return redirect(url_for('auth.login'))
 
     passes = Pass.query.filter(Pass.checkin_at != None).order_by(
         Pass.date.desc(), Pass.checkout_at.desc()

--- a/src/routes/students.py
+++ b/src/routes/students.py
@@ -18,7 +18,7 @@ config = load_config()
 @students_bp.route('/students')
 def manage_students():
     if not session.get('logged_in'):
-        return redirect(url_for('auth.admin_login'))
+        return redirect(url_for('auth.login'))
 
     students = User.query.filter_by(role="student").all()
     return render_template('students.html', students=students)
@@ -30,7 +30,7 @@ def manage_students():
 @students_bp.route('/students/download')
 def download_students_csv():
     if not session.get('logged_in'):
-        return redirect(url_for('auth.admin_login'))
+        return redirect(url_for('auth.login'))
 
     from src.models import StudentSchedule
 
@@ -65,7 +65,7 @@ def download_students_csv():
 @students_bp.route('/students/upload', methods=['POST'])
 def upload_students_csv():
     if not session.get('logged_in') or session.get('role') != "admin":
-        return redirect(url_for('auth.admin_login'))
+        return redirect(url_for('auth.login'))
 
     file = request.files.get('csv_file')
     if not file:
@@ -127,7 +127,7 @@ def upload_students_csv():
 @students_bp.route('/students/add', methods=['POST'])
 def add_student():
     if not session.get('logged_in'):
-        return redirect(url_for('auth.admin_login'))
+        return redirect(url_for('auth.login'))
 
     student_id = request.form.get('id').strip()
     name = request.form.get('name').strip()


### PR DESCRIPTION
## Summary
- update redirects to use `auth.login` instead of the removed `auth.admin_login`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6840637d868083268eb3b43541d12dd9